### PR TITLE
 rl-492/openapi-generator OpenapiGenerator:

### DIFF
--- a/dev.md
+++ b/dev.md
@@ -6,11 +6,7 @@ All custom logic, on top of generated files, should be places in `/src/ext` fold
 
 To regenerate models from openapi definition, 
 clone [latest open api definitions](https://github.com/regulaforensics/DocumentReader-api-openapi)
-and set `DEFINITION_FOLDER` as path to cloned directory, for example:
-```bash
-export DOCS_DEFINITION_FOLDER="/home/user/projects/DocumentReader-api-openapi"
-```
-Then use next command from the project root:
+and use next command from the project root:
 ```bash
 ./update-models.sh
 ```

--- a/update-models.sh
+++ b/update-models.sh
@@ -3,7 +3,7 @@
 DOCS_DEFINITION_FOLDER="${PWD}/../DocumentReader-web-openapi" \
 \
 && docker run --user "$(id -u):$(id -g)" --rm -v "${PWD}:/client" -v "$DOCS_DEFINITION_FOLDER:/definitions" \
-openapitools/openapi-generator-cli:v5.0.0-beta generate -g typescript-axios \
+openapitools/openapi-generator-cli:v5.0.0-beta2 generate -g typescript-axios \
 -i /definitions/index.yml -o /client/src -c /client/ts-generator-config.json \
 -t /client/generator-templates/ || exit 1
 

--- a/update-models.sh
+++ b/update-models.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
-docker run --user "$(id -u):$(id -g)" --rm -v "${PWD}:/client" -v "${DOCS_DEFINITION_FOLDER}:/definitions" \
-openapitools/openapi-generator-cli generate -g typescript-axios \
+DOCS_DEFINITION_FOLDER="${PWD}/../DocumentReader-web-openapi" \
+\
+&& docker run --user "$(id -u):$(id -g)" --rm -v "${PWD}:/client" -v "$DOCS_DEFINITION_FOLDER:/definitions" \
+openapitools/openapi-generator-cli:v5.0.0-beta generate -g typescript-axios \
 -i /definitions/index.yml -o /client/src -c /client/ts-generator-config.json \
 -t /client/generator-templates/ || exit 1
 


### PR DESCRIPTION
- add ability to run v5.0.0-beta2 openapi generator version
- add ability to run update-models.sh without DOCS_DEFINITION_FOLDER environment